### PR TITLE
Feature mpi distribution

### DIFF
--- a/pandana/core/loader.py
+++ b/pandana/core/loader.py
@@ -1,22 +1,48 @@
 from pandana.core.tables import Tables
+from pandana.utils.mpiutils import round_robin
+import time
+from mpi4py import MPI
 
 
 class Loader:
     """A class for accessing data in h5py files."""
 
     def __init__(self, files, idcol, main_table_name, indices):
-        self._files = files
         self._idcol = idcol
         self._main_table_name = main_table_name
         self._indices = indices
 
         self._specdefs = []
 
+        # If we have more ranks than files,
+        # distribute files among ranks to reduce the number of
+        # system calls
+        # 64 ranks can read from 4 files by having 16 ranks read each file
+        # for a total of 64 system calls.
+        # compare to if each rank read a slice of each file ( 64 * 4 = 256 system calls)
+
+        comm = MPI.COMM_WORLD
+        if comm.size > len(files):
+            self._local_rank_id = comm.rank // len(files)
+            self._nranks_per_file, leftover = divmod(comm.size, len(files))
+            offset = comm.rank % len(files)
+            if offset < self._leftover:
+                self._nranks_per_file += 1
+            self._files = [files[offset]]
+
+        else:
+            self._nranks_per_file = comm.size
+            self._local_rank_id = comm.rank
+            self._files = files[comm.rank :: comm.size]
+
+        self.rank = comm.rank
+
     def add_spectrum(self, spec):
         if not spec in self._specdefs:
             self._specdefs.append(spec)
 
     def Go(self):
+        print(f"[{self.rank}] Loader.Go: {time.perf_counter()}")
         """
         Iterate through the associated spectra and compute the cuts and vars for each
         :return: None
@@ -24,7 +50,11 @@ class Loader:
         for f in self._files:
             # Construct the tables for this file
             tables = Tables(
-                f, self._idcol, self._main_table_name, indices=self._indices
+                f,
+                self._idcol,
+                self._main_table_name,
+                indices=self._indices,
+                nranks_per_file=self._nranks_per_file,
             )
 
             # FILL ALL SPECTRA for this file
@@ -36,6 +66,7 @@ class Loader:
         self.Finish()
 
     def Finish(self):
+        print(f"[{self.rank}] Loader.Finish: {time.perf_counter()}")
         # Combine together result for each file
         for spec in self._specdefs:
             spec.finish()

--- a/pandana/core/loader.py
+++ b/pandana/core/loader.py
@@ -1,5 +1,4 @@
 from pandana.core.tables import Tables
-from pandana.utils.mpiutils import round_robin
 import time
 from mpi4py import MPI
 
@@ -20,22 +19,33 @@ class Loader:
         # 64 ranks can read from 4 files by having 16 ranks read each file
         # for a total of 64 system calls.
         # compare to if each rank read a slice of each file ( 64 * 4 = 256 system calls)
-
         comm = MPI.COMM_WORLD
-        if comm.size > len(files):
+        if comm.size >= len(files):
             self._local_rank_id = comm.rank // len(files)
             self._nranks_per_file, leftover = divmod(comm.size, len(files))
+            # warn if ranks aren't evenly divided into files
+            if leftover and comm.rank == 0:
+                print(
+                    (
+                        "Warning: Some ranks will do more reading "
+                        "than others. "
+                        "Change number of ranks to be evenly divisible by "
+                        "total number of files for better performance."
+                    )
+                )
+
             offset = comm.rank % len(files)
-            if offset < self._leftover:
+            if offset < leftover:
                 self._nranks_per_file += 1
             self._files = [files[offset]]
 
         else:
             self._nranks_per_file = comm.size
             self._local_rank_id = comm.rank
-            self._files = files[comm.rank :: comm.size]
+            self._files = files
 
         self.rank = comm.rank
+        self._tables = []
 
     def add_spectrum(self, spec):
         if not spec in self._specdefs:
@@ -49,19 +59,22 @@ class Loader:
         """
         for f in self._files:
             # Construct the tables for this file
-            tables = Tables(
-                f,
-                self._idcol,
-                self._main_table_name,
-                indices=self._indices,
-                nranks_per_file=self._nranks_per_file,
+            self._tables.append(
+                Tables(
+                    f,
+                    self._idcol,
+                    self._main_table_name,
+                    indices=self._indices,
+                    nranks_per_file=self._nranks_per_file,
+                    local_rank_id=self._local_rank_id,
+                )
             )
 
             # FILL ALL SPECTRA for this file
             for spec in self._specdefs:
-                spec.fill(tables)
+                spec.fill(self._tables[-1])
 
-            tables.closeFile()
+            self._tables[-1].closeFile()
 
         self.Finish()
 

--- a/pandana/core/spectrum.py
+++ b/pandana/core/spectrum.py
@@ -21,17 +21,18 @@ class Spectrum:
     def fill(self, tables):
         # Compute the var and complete cut
         dfvar = self._var(tables)
-        dfcut = self._cut(tables)
+        if self._cut is not None:
+            dfcut = self._cut(tables)
 
-        # We allow the cut to have any subset of the indices used in the var
-        # The two dataframes need to be aligned in this case
-        if not dfvar.index.equals(dfcut.index):
-            # When aligning, the cut and var have to be of the same type
-            if isinstance(dfvar, pd.DataFrame):
-                dfvar, dfcut = dfvar.align(dfcut.to_frame(), axis=0, join="inner")
-            else:
-                dfvar, dfcut = dfvar.align(dfcut, axis=0, join="inner")
-        dfvar = dfvar.loc[dfcut.to_numpy()]
+            # We allow the cut to have any subset of the indices used in the var
+            # The two dataframes need to be aligned in this case
+            if not dfvar.index.equals(dfcut.index):
+                # When aligning, the cut and var have to be of the same type
+                if isinstance(dfvar, pd.DataFrame):
+                    dfvar, dfcut = dfvar.align(dfcut.to_frame(), axis=0, join="inner")
+                else:
+                    dfvar, dfcut = dfvar.align(dfcut, axis=0, join="inner")
+            dfvar = dfvar.loc[dfcut.to_numpy()]
 
         # Compute weights
         if self._wgt is not None:

--- a/pandana/core/tables.py
+++ b/pandana/core/tables.py
@@ -7,7 +7,7 @@ from pandana.core.datagroup import DataGroup
 
 class Tables:
     def __init__(self, f, idcol, main_table_name, indices):
-        self._file = h5py.File(f, "r")
+        self._file = h5py.File(f, "r", driver='mpio', comm=MPI.COMM_WORLD)
         self._idcol = idcol
         self._main_table_name = main_table_name
         self._indices = indices

--- a/pandana/core/tables.py
+++ b/pandana/core/tables.py
@@ -6,8 +6,8 @@ from pandana.core.datagroup import DataGroup
 
 
 class Tables:
-    def __init__(self, f, idcol, main_table_name, indices):
-        self._file = h5py.File(f, "r", driver='mpio', comm=MPI.COMM_WORLD)
+    def __init__(self, f, idcol, main_table_name, indices, nranks_per_file):
+        self._file = h5py.File(f, "r", driver="mpio", comm=MPI.COMM_WORLD)
         self._idcol = idcol
         self._main_table_name = main_table_name
         self._indices = indices
@@ -18,7 +18,7 @@ class Tables:
         comm = MPI.COMM_WORLD
         if comm.size > 1:
             self._begin_evt, self._end_evt = self.calculateEventRange(
-                self._file.get(self._main_table_name), comm.rank, comm.size
+                self._file.get(self._main_table_name), comm.rank, nranks_per_file
             )
 
         self._keys = {}
@@ -41,10 +41,10 @@ class Tables:
             )
         return self._keys[key]
 
-    def calculateEventRange(self, group, rank, nranks):
+    def calculateEventRange(self, group, rank, nranks_per_file):
         assert group is not None
         begin, end = utils.mpiutils.calculate_slice_for_rank(
-            rank, nranks, group[self._idcol].size
+            rank, nranks_per_file, group[self._idcol].size
         )
         span = group[self._idcol][begin:end].flatten()
         b, e = span[0], span[-1]

--- a/pandana/core/tables.py
+++ b/pandana/core/tables.py
@@ -6,8 +6,10 @@ from pandana.core.datagroup import DataGroup
 
 
 class Tables:
-    def __init__(self, f, idcol, main_table_name, indices, nranks_per_file):
-        self._file = h5py.File(f, "r", driver="mpio", comm=MPI.COMM_WORLD)
+    def __init__(
+        self, f, idcol, main_table_name, indices, nranks_per_file, local_rank_id
+    ):
+        self._file = h5py.File(f, "r")  # , driver="mpio", comm=MPI.COMM_WORLD)
         self._idcol = idcol
         self._main_table_name = main_table_name
         self._indices = indices
@@ -18,7 +20,7 @@ class Tables:
         comm = MPI.COMM_WORLD
         if comm.size > 1:
             self._begin_evt, self._end_evt = self.calculateEventRange(
-                self._file.get(self._main_table_name), comm.rank, nranks_per_file
+                self._file.get(self._main_table_name), local_rank_id, nranks_per_file
             )
 
         self._keys = {}

--- a/pandana/utils/mpiutils.py
+++ b/pandana/utils/mpiutils.py
@@ -10,9 +10,9 @@ def calculate_slice_for_rank(myrank, nranks_per_file, arraysz):
     a total nranks. We assure as equitable a distribution of ranks as
     possible.
     """
-
-    local_rank_id = myrank % nranks_per_file
-    if nranks > arraysz:
+    if myrank > nranks_per_file:
+        raise ValueError("myrank must not be larger than ranks assigned to this file")
+    if nranks_per_file > arraysz:
         raise ValueError("nranks must not be larger than array size")
 
     # Each rank will get either minsize or minsize+1 elements to work on.
@@ -20,15 +20,15 @@ def calculate_slice_for_rank(myrank, nranks_per_file, arraysz):
 
     # Ranks [0, leftovers) get minsize+1 elements
     # Ranks [leftovers, nranks) get minsize elements
-    slice_size = minsize + 1 if local_rank_id < leftovers else minsize
+    slice_size = minsize + 1 if myrank < leftovers else minsize
 
     if myrank < leftovers:
-        low = local_rank_id * slice_size
+        low = myrank * slice_size
         high = low + slice_size
     else:
         # The calculation of 'low' is the algebraically simplified version of
         # the more obvious:
         #  low = leftovers*(my_size_size_bytes + 1) + (myrank - leftovers)*my_size_size_bytes
-        low = leftovers + local_rank_id * slice_size
+        low = leftovers + myrank * slice_size
         high = low + slice_size
     return low, high

--- a/tests/test_parallel_read.py
+++ b/tests/test_parallel_read.py
@@ -1,23 +1,37 @@
 import argparse
 from mpi4py import MPI
+import pandas as pd
 
 parser = argparse.ArgumentParser()
-parser.add_argument('file_list')
+parser.add_argument("file_list")
 args = parser.parse_args()
 
 from pandana.core.loader import Loader
-from pandana.core.tables import Tables
-from pandana.core.datagroup import DataGroup
+from pandana.core.spectrum import Spectrum
+from pandana.core.var import Var
 
-with open(args.file_list, 'r') as f:
+with open(args.file_list, "r") as f:
     files = [l.strip() for l in f.readlines()]
 
-loader = Loader(files, 'evt.seq', 'spill', [])
+
+KL = ["run", "subrun", "cycle", "batch", "evt", "subevt"]
+loader = Loader(files, "evt.seq", "spill", indices=KL,)
+
+
+evt_seq_spec = Spectrum(loader, None, Var(lambda tables: tables["rec.slc"]["evt.seq"]))
+
+loader.Go()
+
+evt_seq = evt_seq_spec.df().reset_index()[KL + ["evt.seq"]]
 
 comm = MPI.COMM_WORLD
+evt_seq = comm.gather(evt_seq, root=0)
 
 
-print(comm.rank, loader._local_rank_id, loader._nranks_per_file, loader._files)
+if comm.rank == 0:
+    evt_seq = pd.concat(evt_seq)
+    assert evt_seq.shape == evt_seq.drop_duplicates().shape
 
-
-
+    # if assertion is passed and shape is the same
+    # as when read with one rank, then consider this working
+    print(evt_seq.shape)

--- a/tests/test_parallel_read.py
+++ b/tests/test_parallel_read.py
@@ -1,0 +1,23 @@
+import argparse
+from mpi4py import MPI
+
+parser = argparse.ArgumentParser()
+parser.add_argument('file_list')
+args = parser.parse_args()
+
+from pandana.core.loader import Loader
+from pandana.core.tables import Tables
+from pandana.core.datagroup import DataGroup
+
+with open(args.file_list, 'r') as f:
+    files = [l.strip() for l in f.readlines()]
+
+loader = Loader(files, 'evt.seq', 'spill', [])
+
+comm = MPI.COMM_WORLD
+
+
+print(comm.rank, loader._local_rank_id, loader._nranks_per_file, loader._files)
+
+
+


### PR DESCRIPTION
Change how parallel reads are distributed. If nranks are greater than number of files, divide ranks among files. Else, divide files among ranks. 

This is done by using the same partionining functions, but instead of considering the global number of files and ranks, parameters are passed to describe the local number of files (1) and ranks and assigning ranks accordingly. 

If the user attempts to use a number of ranks that is not a multiple of the number of files, a warning is printed

If the number of files is greater than the number of ranks, we fall back to the original distribution scheme